### PR TITLE
updated README.md instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,9 @@ For example, if your riak_explorer repo is located at
 ```bash
 export EXPLORER_PATH=/Users/yourusername/code/riak_explorer
 
+make recompile
+
 cp -R dist/* $EXPLORER_PATH/priv/ember_riak_explorer/dist
-```
-
-Then, during subsequent development, you can just run:
-
-```bash
-make recompile && cp -R dist/* $EXPLORER_PATH/priv/ember_riak_explorer/dist
 ```
 
 (#TODO - consider moving `$EXPLORER_PATH` into the `Makefile`?)


### PR DESCRIPTION
@dmitrizagidulin 

It looks like the asset compiling and the directory copying are happening asynchronously, so the directory contents are copied over before they have been updated. A quick google suggests that `&&` does indeed wait for a running process to finish before executing the next command, so I'm not sure why this is happening. Have you been able to run:

`make recompile && cp -R dist/* $EXPLORER_PATH/priv/ember_riak_explorer/dist`

And get it to run in the correct order? I updated the README docs to reflect this for now.
