### PR TITLE
Remove content security policy in development environment

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -30,6 +30,14 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
+
+    ENV.contentSecurityPolicy = {
+      'default-src': "'none'",
+        'script-src': "'self' 'unsafe-inline' 'unsafe-eval'",
+        'connect-src': "'self'",
+        'img-src': "'self'",
+        'style-src': "'self' 'unsafe-inline'"
+    }
   }
 
   if (environment === 'test') {


### PR DESCRIPTION
This removes the CSP warnings that show up the javascript console.

Reference: http://stackoverflow.com/questions/26192316/violating-content-security-policy-directive-after-ember-cli-0-0-47-upgrade
