### PR TITLE
Bux fixes regarding accessing certain ember data attributes

### DIFF
--- a/app/pods/bucket/model.js
+++ b/app/pods/bucket/model.js
@@ -129,16 +129,24 @@ var Bucket = DS.Model.extend({
      * @default 'riak-object'
      */
     objectModelName: function() {
-        if(this.get('props').get('isCounter')) {
-            return 'riak-object.counter';
+        let modelType = null;
+
+        switch(true) {
+            case this.get('props').get('isCounter'):
+                modelType = 'riak-object.counter';
+                break;
+            case this.get('props').get('isSet'):
+                modelType = 'riak-object.set';
+                break;
+            case this.get('props').get('isMap'):
+                modelType = 'riak-object.map';
+                break;
+            default:
+                modelType = 'riak-object';
+                break;
         }
-        if(this.get('props').get('isSet')) {
-            return 'riak-object.set';
-        }
-        if(this.get('props').get('isMap')) {
-            return 'riak-object.map';
-        }
-        return 'riak-object';
+
+        return modelType;
     }.property('props'),
 
     /**

--- a/app/pods/riak-object/map/model.js
+++ b/app/pods/riak-object/map/model.js
@@ -79,9 +79,10 @@ var RiakObjectMap = RiakObject.extend({
      * @method contentsForDisplay
      * @return {String}
      */
-    contentsForDisplay: function() {
-        return JSON.stringify(this.get('contents'));
-    }.property('contents'),
+    // TODO: this is throwing "Converting circular structure to JSON" error
+    //contentsForDisplay: function() {
+    //    return JSON.stringify(this.get('contents'));
+    //}.property('contents'),
 
     /**
      * Hashmap of counters (`RiakObjectMapField` instances) for this map,


### PR DESCRIPTION
I did the same fixes you just merged in, thats pretty funny. Maybe we could get a +1 system on PR's going both ways, that way all work gets a second set of eyes. I did notice also that the `contentsForDisplay` method on the map model is throwing a circular reference error due to how Ember Data is creating the model relationship references. 

This is fine for now because the map view is currently not calling the method, but if we ever want to implement something like jstree, we are going to need the full json payload. I think the correct way to pass the full json is to create an attribute on the model (something like `rawJSON: DS.attr()`), and then in the serializer that handles the api call, store that value on the model. 

I can implement this if you want, but I don't want to get sidetracked from other more pressing work. Lets create a seperate ticket for this.

[SO Reference](http://stackoverflow.com/questions/33262879/how-to-access-raw-json-payload-from-remote-service-in-ember-when-using-ember-dat)
