### PR TITLE
Visual tweaks for bucket and bucket type views

### DIFF
--- a/app/pods/bucket-type/template.hbs
+++ b/app/pods/bucket-type/template.hbs
@@ -9,7 +9,7 @@
 </div>
 
 <div class='bucket-types-container'>
-  {{#dashboard-module label='Properties'}}
+  {{#dashboard-module}}
 
     {{#if model.props}}
       {{#em-tabs class='half-width'}}
@@ -21,18 +21,15 @@
         {{#em-tab-panel}}
           <table class='key-value-table'>
             <tr>
-              <td class='key'>Bucket Status:</td>
+              <td class='key'>Object type:</td>
               <td class='value'>
+                {{model.props.objectType}}
                 {{#if model.isActive}}
                   <span class="label label-success">Active</span>
                 {{else}}
                   <span class="label label-default">Inactive</span>
                 {{/if}}
               </td>
-            </tr>
-            <tr>
-              <td class='key'>Object type:</td>
-              <td class='value'>{{model.props.objectType}}</td>
             </tr>
             <tr>
               <td class='key'>Conflict Res. Strategy:</td>

--- a/app/pods/bucket/template.hbs
+++ b/app/pods/bucket/template.hbs
@@ -10,7 +10,7 @@
 </div>
 
 <div class='bucket-types-container'>
-  {{#dashboard-module label='Properties'}}
+  {{#dashboard-module}}
     {{#if model.props}}
       {{#em-tabs class='half-width'}}
         {{#em-tab-list}}

--- a/app/templates/components/bucket-properties.hbs
+++ b/app/templates/components/bucket-properties.hbs
@@ -1,12 +1,8 @@
 <table class='key-value-table'>
   <tr>
-    <td class='key'>Bucket Status:</td>
+    <td class='key'>Bucket Name:</td>
     <td class='value'>
-      {{#if model.isActive}}
-        <span class="label label-success">Active</span>
-      {{else}}
-        <span class="label label-default">Inactive</span>
-      {{/if}}
+      {{model.name}}
     </td>
   </tr>
   <tr>

--- a/app/templates/components/link/link-bucket.hbs
+++ b/app/templates/components/link/link-bucket.hbs
@@ -1,5 +1,3 @@
-{{#link-to 'bucket' bucket
-        classNames='btn btn-sm btn-primary btn-block cluster-resource-link' }}
-    <span class="glyphicon glyphicon-folder-close cluster-resource-icon"
-        aria-hidden="true"></span>
-    {{bucket.bucketId}}{{/link-to}}
+{{#link-to 'bucket' bucket }}
+  {{bucket.bucketId}}
+{{/link-to}}


### PR DESCRIPTION
- Removes "properties" header from bucket and bucket type views
- Consistently styles button lists
- Removes active label from bucket detail view (assumes all buckets inside of an active bucket type must be active)
- Moves active label on bucket type to be next to bucket name

[JIRA Story #94](https://bashoeng.atlassian.net/browse/REX-94)
