### PR TITLE
Fix Search Index section in Bucket and Bucket Type views

### DIFF
--- a/app/pods/bucket-type/model.js
+++ b/app/pods/bucket-type/model.js
@@ -58,7 +58,7 @@ var BucketType = DS.Model.extend({
     index: function() {
         return this.get('cluster').get('indexes')
             .findBy('name', this.get('props').get('searchIndexName'));
-    }.property('cluster'),
+    }.property('cluster', 'props'),
 
     /**
      * Returns true if this Bucket Type has been activated.
@@ -84,7 +84,7 @@ var BucketType = DS.Model.extend({
      * Alias for the record's `id`, which is a composite ID in the form of
      *     `'<clusterId>/<bucketName>'`.
      * @see ExplorerResourceAdapter.normalizeId
-     * 
+     *
      * @property name
      * @type String
      * @example

--- a/app/pods/bucket-type/template.hbs
+++ b/app/pods/bucket-type/template.hbs
@@ -52,23 +52,33 @@
               </td>
             </tr>
 
-            {{#if model.props.props.isSearchIndexed}}
+            {{#if model.props.isSearchIndexed}}
               <tr>
                 <td class='key'>Search Index:</td>
                 <td class='value'>{{model.props.searchIndexName}}</td>
               </tr>
-              <tr>
-                <td class='key'>Search Schema:</td>
-                <td class='value'>
-                  <a href="{{model.props.cluster.clusterProxyUrl}}/search/schema/{{model.props.index.schema}}">
-                    {{model.props.index.schema}}
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td class='key'>Index N_Val:</td>
-                <td class='value'>{{model.props.index.n_val}}</td>
-              </tr>
+              {{#if model.index}}
+                <tr>
+                  <td class='key'>Search Schema:</td>
+                  <td class='value'>
+                    <a href="{{model.cluster.proxyUrl}}/search/schema/{{model.index.schema}}">
+                      {{model.index.schema}}
+                    </a>
+                  </td>
+                </tr>
+                <tr>
+                  <td class='key'>Index N_Val:</td>
+                  <td class='value'>{{model.index.n_val}}</td>
+                </tr>
+              {{else}}
+                <tr>
+                    <td class='key'></td>
+                    <td class='value'>
+                      <em>Warning: Index with id <code>{{model.props.searchIndexName}}</code>
+                        has not been created on this cluster!</em>
+                    </td>
+                </tr>
+              {{/if}}
             {{else}}
               <tr>
                 <td class='key'>Search Index:</td>

--- a/app/styles/components/_key-value-table.scss
+++ b/app/styles/components/_key-value-table.scss
@@ -1,7 +1,6 @@
 .key-value-table {
   th, td {
     padding-bottom: 10px;
-    text-transform: capitalize;
     vertical-align: top;
 
     &.key {

--- a/app/templates/components/bucket-properties.hbs
+++ b/app/templates/components/bucket-properties.hbs
@@ -34,18 +34,28 @@
       <td class='key'>Search Index:</td>
       <td class='value'>{{model.props.searchIndexName}}</td>
     </tr>
-    <tr>
-      <td class='key'>Search Schema:</td>
-      <td class='value'>
-        <a href="{{model.props.cluster.clusterProxyUrl}}/search/schema/{{model.props.index.schema}}">
-          {{model.props.index.schema}}
-        </a>
-      </td>
-    </tr>
-    <tr>
-      <td class='key'>Index N_Val:</td>
-      <td class='value'>{{model.props.index.n_val}}</td>
-    </tr>
+    {{#if model.index}}
+      <tr>
+        <td class='key'>Search Schema:</td>
+        <td class='value'>
+          <a href="{{model.cluster.proxyUrl}}/search/schema/{{model.index.schema}}">
+            {{model.index.schema}}
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td class='key'>Index N_Val:</td>
+        <td class='value'>{{model.index.n_val}}</td>
+      </tr>
+    {{else}}
+      <tr>
+          <td class='key'></td>
+          <td class='value'>
+            <em>Warning: Index with id <code>{{model.props.searchIndexName}}</code>
+              has not been created on this cluster!</em>
+          </td>
+      </tr>
+    {{/if}}
   {{else}}
     <tr>
       <td class='key'>Search Index:</td>


### PR DESCRIPTION
- Fix search index and schema display code
- Add a warning for cases when an index name has been set
  as a bucket (or bucket type's) search_index property,
      but that index has not yet been actually created
- Remove Capitalize directive for props values divs
    (since many Riak values are case-sensitive)

Closes #16.
