### PR TITLE
Removes unused ember-bootstrap npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
-    "ember-bootstrap": "0.1.4",
     "ember-cli": "1.13.6",
     "ember-cli-app-version": "0.4.0",
     "ember-cli-babel": "^5.0.0",


### PR DESCRIPTION
I was getting some watchman recrawl warnings when I was running `ember server`. I went spelunking and found out it had to do with a stale package of watchman running on osx el capitan. If anyone is getting the same errors, [follow this advice](https://github.com/ember-cli/ember-cli/issues/2703#issuecomment-75886720).

While spelunking I removed my `node_modules` and `bower_components` directory and reinstalled and was getting an error in regards to bootstrap not being present even though the package was included. We are not using the ember-bootstrap package, opting for bootstrap-sass instead. Hence the package removal.
