### PR TITLE
switch isNewSerializerAPI flag to true

### DIFF
--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -12,11 +12,11 @@ export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
 
     /**
     This indicates that the
-        store should call `normalizeResponse` instead of `extract` and to expect
-        a JSON-API Document back.
+    store should call `normalizeResponse` instead of `extract` and to expect
+    a JSON-API Document back.
     @property isNewSerializerAPI
     */
-    isNewSerializerAPI: false,
+    isNewSerializerAPI: true,
 
     /**
      `keyForAttribute` can be used to define rules for how to convert an


### PR DESCRIPTION
I did a quick spike to see what kind of effort is involved in removing all deprecation warnings, so that when we do want to upgrade to Ember 2 and Ember Data 2 we have the ability to do so. Switching this flag seemed to remove most warnings. @dmitrizagidulin you are more familiar with how all the ember data pieces are implemented (adapters, serializers, etc.). It seems to me that while the explorer service is not jsonapi compliant, all the correct data mutating is happening at the serializer and adapter levels, hence the ember app can treat it as using the new serializer api.

Is there any gotchas that you are aware of? I ran the app with this flag and everything seemed to functioning correctly.
