### PR TITLE
Flip loaded flag if cache not created

### DIFF
--- a/app/services/explorer.js
+++ b/app/services/explorer.js
@@ -683,6 +683,7 @@ export default Ember.Service.extend({
                 error: function(jqXHR, textStatus) {
                     // Fail (likely a 404, cache not yet created)
                     if(jqXHR.status === 404) {
+                        bucketType.set('isBucketListLoaded', false);
                         // Kick off a Cache Refresh, and repeat the getBucketList request
                         console.log("kicking off cache refresh...");
                         explorer.bucketCacheRefresh(clusterId, bucketTypeId);
@@ -920,6 +921,7 @@ export default Ember.Service.extend({
                 },
                 error: function (jqXHR, textStatus) {
                     if (jqXHR.status === 404) {
+                        bucket.set('isKeyListLoaded', false);
                         // Empty cache (need to kick off a refresh)
                         explorer.keyCacheRefresh(clusterId, bucketTypeId, bucketId);
                         // Results in returning an empty (Loading..) key list


### PR DESCRIPTION
Fixes [JIRA 104](https://bashoeng.atlassian.net/browse/REX-104)

When a bucket or key was deleted, a new cache list needs to be created. The loaded flag was originally set on original creation, but once the cache was purged the flag was never switched. 

@dmitrizagidulin Does it make sense to call the cache refresh calls right after any action that renders the list stale, rather than wait for a 404 server error?
