### PR TITLE
Sort clusters in left navigation by name

### DIFF
--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -30,5 +30,15 @@ export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     keyForAttribute: function(attr , method) {
         // Riak and Explorer json uses snake case, like 'development_mode'
         return Ember.String.underscore(attr);
+    },
+
+    normalizeResponse: function(store, primaryModelClass, payload, id, requestType) {
+        let sortBy = Ember.Enumerable.sortBy;
+
+        if (payload.clusters) {
+            payload.clusters = payload.clusters.sortBy('id');
+        }
+
+        return this._super(store, primaryModelClass, payload, id, requestType);
     }
 });

--- a/app/serializers/bucket-type.js
+++ b/app/serializers/bucket-type.js
@@ -2,18 +2,10 @@ import ApplicationSerializer from './application';
 import Ember from 'ember';
 
 export default ApplicationSerializer.extend({
-    modelNameFromPayloadKey: function(payloadKey) {
-        if (payloadKey === 'nodes') {
-            payloadKey = 'riak-node';
-        }
-
-        return this._super(payloadKey);
-    },
-
     normalizeResponse: function(store, primaryModelClass, payload, id, requestType) {
         let sortBy = Ember.Enumerable.sortBy;
 
-        payload.nodes = payload.nodes.sortBy('id');
+        payload.bucket_types = payload.bucket_types.sortBy('original_id');
 
         return this._super(store, primaryModelClass, payload, id, requestType);
     }


### PR DESCRIPTION
Fixes #43 
- Created an application controller and put sorting logic inside. This is where I felt was the best place for this logic, as controllers are basically meant to decorate templates for visual logic that the model is not concerned with.

Question: Should any other kind of lists (Bucket Types, Buckets, Keys, etc.) be sorted by name?
