### PR TITLE
Riak type

### DIFF
--- a/app/pods/cluster/model.js
+++ b/app/pods/cluster/model.js
@@ -44,6 +44,13 @@ var Cluster = DS.Model.extend({
     indexes: DS.attr(),
 
     /**
+     * The Riak Type: either Open Source (oss) or Enterprise Edition (ee)
+     * @property riakType
+     * @type String
+     */
+    riakType: DS.attr('string', { defaultValue: 'oss' }),
+
+    /**
      * Returns a list of currently activated bucket types.
      *
      * @method activeBucketTypes
@@ -73,6 +80,26 @@ var Cluster = DS.Model.extend({
     inactiveBucketTypes: function() {
         return this.get('bucketTypes').filterBy('isInactive');
     }.property('bucketTypes'),
+
+    /**
+     * Boolean test on if the riakType is the open source edition
+     *
+     * @method isOpenSourceEdition
+     * @return Boolean
+     */
+    isOpenSourceEdition: function() {
+      return this.get('riakType') === 'oss';
+    }.property('riakType'),
+
+    /**
+     * Boolean test on if the riakType is the enterprise edition
+     *
+     * @method isEnterpriseEdition
+     * @return Boolean
+     */
+    isEnterpriseEdition: function() {
+        return this.get('riakType') === 'ee';
+    }.property('riakType'),
 
     /**
      * Returns true if this cluster is in production mode (development_mode=off)

--- a/app/pods/cluster/template.hbs
+++ b/app/pods/cluster/template.hbs
@@ -1,61 +1,92 @@
 <div class='view-header'>
-  {{breadcrumb-component clusterId=model.id}}
-  {{view-label
-  pre-label='Cluster'
-  label=model.id}}
+    {{breadcrumb-component clusterId=model.id}}
+    {{view-label
+    pre-label='Cluster'
+    label=model.id}}
 </div>
 
 <div class='cluster-information-container'>
-  {{#dashboard-module label='Active Bucket Types'}}
-    {{#if model.activeBucketTypes}}
-      {{bucket-types
-      clusterId=model.clusterId
-      bucketTypes=model.activeBucketTypes}}
-    {{else}}
-      <p>No bucket types have been activated</p>
-    {{/if}}
-  {{/dashboard-module}}
+    {{#dashboard-module label='Cluster Properties'}}
+        <table class="key-value-table">
+            <tbody>
+            <tr>
+                <td class="key">Development Mode</td>
+                <td class="value">
+                    {{#if model.developmentMode}}
+                        On
+                    {{else}}
+                        Off
+                    {{/if}}
+                </td>
+            </tr>
+            <tr>
+                <td class="key">Edition Type</td>
+                <td class="value">
+                    {{#if model.isEnterpriseEdition}}
+                        Enterprise
+                    {{else}}
+                        {{#if model.isOpenSourceEdition}}
+                                Open Source
+                        {{else}}
+                            {{model.riakType}}
+                        {{/if}}
+                    {{/if}}
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    {{/dashboard-module}}
 
-  {{#dashboard-module label='Inactive Bucket Types'}}
-    {{#if model.inactiveBucketTypes}}
-      {{bucket-types
-      clusterId=model.clusterId
-      bucketTypes=model.inactiveBucketTypes}}
-    {{else}}
-      <p>No inactive buckets</p>
-    {{/if}}
-  {{/dashboard-module}}
+    {{#dashboard-module label='Active Bucket Types'}}
+        {{#if model.activeBucketTypes}}
+            {{bucket-types
+            clusterId=model.clusterId
+            bucketTypes=model.activeBucketTypes}}
+        {{else}}
+            <p>No bucket types have been activated</p>
+        {{/if}}
+    {{/dashboard-module}}
 
-  {{#dashboard-module label='Search Indexes'}}
-    {{#if model.indexes}}
-      {{search-indexes
-      indexes=model.indexes
-      clusterProxyUrl=model.proxyUrl}}
-    {{else}}
-      <p>No search indexes found</p>
-    {{/if}}
-  {{/dashboard-module}}
+    {{#dashboard-module label='Inactive Bucket Types'}}
+        {{#if model.inactiveBucketTypes}}
+            {{bucket-types
+            clusterId=model.clusterId
+            bucketTypes=model.inactiveBucketTypes}}
+        {{else}}
+            <p>No inactive buckets</p>
+        {{/if}}
+    {{/dashboard-module}}
 
-  {{#dashboard-module label='Nodes'}}
-    {{#if model.riakNodes}}
-      <ul class="button-list">
-          {{#each model.riakNodes as |node|}}
-              <li>
-                  <a href="node-stats?nodeId={{node.id}}&clusterId={{model.id}}"
-                     class={{unless node.available "danger"}}>
-                      {{node.id}}
-                      <span
-                          class="glyphicon {{if node.available "glyphicon-ok-circle" "glyphicon-ban-circle"}}"
-                          aria-hidden="true">
+    {{#dashboard-module label='Search Indexes'}}
+        {{#if model.indexes}}
+            {{search-indexes
+            indexes=model.indexes
+            clusterProxyUrl=model.proxyUrl}}
+        {{else}}
+            <p>No search indexes found</p>
+        {{/if}}
+    {{/dashboard-module}}
+
+    {{#dashboard-module label='Nodes'}}
+        {{#if model.riakNodes}}
+            <ul class="button-list">
+                {{#each model.riakNodes as |node|}}
+                    <li>
+                        <a href="node-stats?nodeId={{node.id}}&clusterId={{model.id}}"
+                           class={{unless node.available "danger"}}>
+                            {{node.id}}
+                            <span
+                                class="glyphicon {{if node.available "glyphicon-ok-circle" "glyphicon-ban-circle"}}"
+                                aria-hidden="true">
                       </span>
-                  </a>
-              </li>
-          {{/each}}
-      </ul>
-    {{else}}
-      <p>No nodes detected</p>
-    {{/if}}
-  {{/dashboard-module}}
+                        </a>
+                    </li>
+                {{/each}}
+            </ul>
+        {{else}}
+            <p>No nodes detected</p>
+        {{/if}}
+    {{/dashboard-module}}
 </div>
 
 


### PR DESCRIPTION
Fixes #45 
- Add `riakType` property to cluster model
- Updates UI to reflect this value

Question: In my current local setup, some of my clusters in the response have a `riak_type` value of `"unavailable"`. Is this a valid type, or do I need to have this be a computed property that is more strict about the values that it will accept (make it only accept `"oss"` or `"ee"`)? 
