### PR TITLE
Display correct key cached list totals, add pagination items count

### DIFF
--- a/app/components/pagination-component.js
+++ b/app/components/pagination-component.js
@@ -54,6 +54,15 @@ export default Ember.Component.extend({
   numberLinks: [],
 
   /**
+   * Stores the total length of the items on which are being paginated
+   *
+   * @property totalSize
+   * @type Integer
+   * @default 0
+   */
+  totalSize: 0,
+
+  /**
    * All actions that the pagination component handles. Upon receiving an action, it updates the state of the component
    * and sends the event "up" for higher level work that it is not aware of.
    *
@@ -66,26 +75,28 @@ export default Ember.Component.extend({
       let requestedRange = this.calculateRequestedRange(chunk);
 
       this.set('currentChunk', chunk);
-      this.sendAction('section-request', requestedRange.low);
+      this.sendAction('sectionRequest', requestedRange.low);
     },
 
     prevLinkClick: function() {
-      if (!this.get('shouldPrevBeHidden')) {
+      if (!this.get('shouldPrevBeDisabled')) {
         let currentChunk = this.get('currentChunk');
         let newChunk = currentChunk - 1;
+        let requestedRange = this.calculateRequestedRange(newChunk);
 
         this.set('currentChunk', newChunk);
-        this.sendAction('section-request', newChunk);
+        this.sendAction('sectionRequest', requestedRange.low);
       }
     },
 
     nextLinkClick: function() {
-      if (!this.get('shouldNextBeHidden')) {
+      if (!this.get('shouldNextBeDisabled')) {
         let currentChunk = this.get('currentChunk');
         let newChunk = currentChunk + 1;
+        let requestedRange = this.calculateRequestedRange(newChunk);
 
         this.set('currentChunk', newChunk);
-        this.sendAction('section-request', newChunk);
+        this.sendAction('sectionRequest', requestedRange.low);
       }
     }
   },
@@ -122,7 +133,7 @@ export default Ember.Component.extend({
    * @return {Object} Contains low and high properties. i.e. { low: 31, high: 40 }
    */
   calculateRequestedRange: function(chunk) {
-    let chunkSize = this.get('chunk-length');
+    let chunkSize = this.get('chunkSize');
 
     return {
       low:  (chunk * chunkSize - chunkSize) + 1,
@@ -138,7 +149,7 @@ export default Ember.Component.extend({
    * @return {Integer}
    */
   calculateNumberLinksCount: function() {
-    let linkCount = Math.ceil(this.get('total-length')/this.get('chunk-length'));
+    let linkCount = Math.ceil(this.get('totalSize')/this.get('chunkSize'));
 
     return this.set('numberLinksCount', linkCount);
   },

--- a/app/components/pagination-component.js
+++ b/app/components/pagination-component.js
@@ -164,6 +164,9 @@ export default Ember.Component.extend({
     this.calculateNumberLinksCount();
 
     if (this.get('shouldShowPaginationLinks')) {
+      // reset numberLinks array
+      this.set('numberLinks', []);
+
       // We want the loop to be 1 indexed, not 0
       for(var i=1; i < this.get('numberLinksCount')+1; i++) {
         this.numberLinks.push(i);

--- a/app/models/cached-list.js
+++ b/app/models/cached-list.js
@@ -45,6 +45,20 @@ var CachedList = DS.Model.extend({
     isLoaded: DS.attr('boolean', {defaultValue: false}),
 
     /**
+     * The index of the first item in the current page, in relation to the entire list
+     * @property firstItemIndex
+     * @type Integer
+     */
+    firstItemIndex: DS.attr('number', {defaultValue: 1}),
+
+    /**
+     * The number of items per page
+     * @property pageSize
+     * @type Integer
+     */
+    pageSize: DS.attr('number', {defaultValue: 0}),
+
+    /**
      * Status message to display to the user. Relevant for long-running
      * server operations such as loading large lists or refreshing cached lists.
      * Sample messages:
@@ -62,7 +76,27 @@ var CachedList = DS.Model.extend({
      * @type Number
      * @default 0
      */
-    total: DS.attr('number', {defaultValue: 0})
+    total: DS.attr('number', {defaultValue: 0}),
+
+    /**
+     * The index of the last item in the current page, in relation to the entire list
+     *
+     * @method lastItemIndex
+     * @returns Integer
+     */
+    lastItemIndex: function() {
+        return this.get('firstItemIndex') + this.get('count') - 1;
+    }.property('firstItemIndex', 'count'),
+
+    /**
+     * Whether or not the current page has more than 1 item in it
+     *
+     * @method lastItemIndex
+     * @returns Boolean
+     */
+    multipleListItems: function() {
+        return this.get('count') > 1;
+    }.property('count')
 });
 
 export default CachedList;

--- a/app/pods/bucket-type/controller.js
+++ b/app/pods/bucket-type/controller.js
@@ -52,10 +52,8 @@ var BucketTypeController = Ember.Controller.extend({
             let bucketType = this.get('model');
             let cluster = bucketType.get('cluster');
             let store = this.get('store');
-            let start = startIndex;
-            let rows = bucketType.get('bucketList').get('count');
 
-            return service.getBucketTypeWithBucketList(bucketType, cluster, store, start, rows);
+            return service.getBucketTypeWithBucketList(bucketType, cluster, store, startIndex);
         },
 
         refreshBuckets: function(bucketType) {

--- a/app/pods/bucket-type/template.hbs
+++ b/app/pods/bucket-type/template.hbs
@@ -120,10 +120,10 @@
             <tr>
               <td class="key">Cached Bucket List</td>
               <td class="value">
-                {{#if model.keyList.multipleListItems}}
-                    <p>Displaying buckets {{model.keyList.firstItemIndex}}-{{model.keyList.lastItemIndex}} out of {{model.keyList.total}}</p>
+                {{#if model.bucketList.multipleListItems}}
+                    <p>Displaying buckets {{model.bucketList.firstItemIndex}}-{{model.bucketList.lastItemIndex}} out of {{model.bucketList.total}}</p>
                 {{else}}
-                    <p>Displaying bucket {{model.keyList.firstItemIndex}} out of {{model.keyList.total}}</p>
+                    <p>Displaying bucket {{model.bucketList.firstItemIndex}} out of {{model.bucketList.total}}</p>
                 {{/if}}
 
                 {{#pagination-component

--- a/app/pods/bucket-type/template.hbs
+++ b/app/pods/bucket-type/template.hbs
@@ -103,10 +103,6 @@
               <td class="key">Bucket List cache created:</td>
               <td class="value">{{model.bucketList.created}}</td>
             </tr>
-            <tr>
-              <td class="key">Total buckets in cached list:</td>
-              <td class="value">{{model.bucketList.total}}</td>
-            </tr>
             {{#if model.cluster.developmentMode}}
               <tr>
                 <td class="key">Available actions:</td>
@@ -124,10 +120,16 @@
             <tr>
               <td class="key">Cached Bucket List</td>
               <td class="value">
+                {{#if model.keyList.multipleListItems}}
+                    <p>Displaying buckets {{model.keyList.firstItemIndex}}-{{model.keyList.lastItemIndex}} out of {{model.keyList.total}}</p>
+                {{else}}
+                    <p>Displaying bucket {{model.keyList.firstItemIndex}} out of {{model.keyList.total}}</p>
+                {{/if}}
+
                 {{#pagination-component
-                chunk-length=model.bucketList.count
-                total-length=model.bucketList.total
-                section-request='retrieveRequestedBuckets'}}
+                chunkSize=model.bucketList.pageSize
+                totalSize=model.bucketList.total
+                sectionRequest='retrieveRequestedBuckets'}}
                   <ul class='button-list small'>
                     {{#each model.bucketList.buckets as |bucket|}}
                       <li>

--- a/app/pods/bucket/controller.js
+++ b/app/pods/bucket/controller.js
@@ -46,10 +46,8 @@ var BucketController = Ember.Controller.extend({
             let service = this.get('explorer');
             let bucket  = this.get('model');
             let store   = this.get('store');
-            let start   = startIndex;
-            let rows    = bucket.get('keyList').get('count');
 
-            return service.getBucketWithKeyList(bucket, store, start, rows);
+            return service.getBucketWithKeyList(bucket, store, startIndex);
         },
 
         deleteBucket: function(bucket) {

--- a/app/pods/bucket/template.hbs
+++ b/app/pods/bucket/template.hbs
@@ -48,10 +48,6 @@
             <td class="value">{{model.keyList.created}}</td>
           </tr>
           <tr>
-            <td class="key">Total keys in cached list:</td>
-            <td class="value">{{model.keyList.count}}</td>
-          </tr>
-          <tr>
             <td class="key">Available actions:</td>
             <td class="value">
               <ul class='button-list'>
@@ -74,10 +70,16 @@
           <tr>
             <td class="key">Cached Key List:</td>
             <td class="value">
+              {{#if model.keyList.multipleListItems}}
+                  <p>Displaying keys {{model.keyList.firstItemIndex}}-{{model.keyList.lastItemIndex}} out of {{model.keyList.total}}</p>
+              {{else}}
+                  <p>Displaying key {{model.keyList.firstItemIndex}} out of {{model.keyList.total}}</p>
+              {{/if}}
+
               {{#pagination-component
-              chunk-length=model.keyList.count
-              total-length=model.keyList.total
-              section-request='retrieveRequestedKeys'}}
+              chunkSize=model.keyList.pageSize
+              totalSize=model.keyList.total
+              sectionRequest='retrieveRequestedKeys'}}
                 <ul class='button-list small'>
                   {{#each model.keyList.keys as |obj|}}
                     <li>

--- a/app/services/explorer.js
+++ b/app/services/explorer.js
@@ -217,7 +217,7 @@ export default Ember.Service.extend({
      * @param store {DS.Store}
      * @return {BucketList}
      */
-    createBucketList(data, cluster, bucketType, store) {
+    createBucketList(data, cluster, bucketType, store, startItemIndex) {
         if(!data) {
             // No data, create an empty Bucket list
             return store.createRecord('bucket-list', {
@@ -241,7 +241,9 @@ export default Ember.Service.extend({
             total: data.buckets.total,
             count: data.buckets.count,
             created: data.buckets.created,
-            isLoaded: true
+            isLoaded: true,
+            firstItemIndex: startItemIndex,
+            pageSize: this.pageSize
         });
     },
 
@@ -256,7 +258,7 @@ export default Ember.Service.extend({
      * @param store {DS.Store}
      * @return {KeyList}
      */
-    createKeyList(data, bucket, store) {
+    createKeyList(data, bucket, store, startItemIndex) {
         var explorer = this;
         if(!data) {
             // No data, return an empty KeyList
@@ -283,13 +285,16 @@ export default Ember.Service.extend({
             }
             return obj;
         });
+
         return store.createRecord('key-list', {
             bucket: bucket,
             cluster: bucket.get('cluster'),
             created: data.keys.created,
             count: data.keys.count,
             keys: keyList,
-            total: data.keys.total
+            total: data.keys.total,
+            firstItemIndex: startItemIndex,
+            pageSize: this.pageSize
         });
     },
 
@@ -717,7 +722,7 @@ export default Ember.Service.extend({
                 type: 'GET',
                 success: function(data) {
                     bucketType.set('isBucketListLoaded', true);
-                    resolve(explorer.createBucketList(data, cluster, bucketType, store));
+                    resolve(explorer.createBucketList(data, cluster, bucketType, store, start));
                 },
                 error: function(jqXHR, textStatus) {
                     // Fail (likely a 404, cache not yet created)
@@ -963,7 +968,7 @@ export default Ember.Service.extend({
                 type: 'GET',
                 success: function (data) {
                     bucket.set('isKeyListLoaded', true);
-                    resolve(explorer.createKeyList(data, bucket, store));
+                    resolve(explorer.createKeyList(data, bucket, store, start));
                 },
                 error: function (jqXHR, textStatus) {
                     if (jqXHR.status === 404) {


### PR DESCRIPTION
Fixes issue #55 
- Uses `total` instead of `count` for key and bucket list totals
- Introduces "current range of total" in UI
- Discovered some bugs with the pagination component, and put fixes in place
