### PR TITLE
Readd pending test support back in. Fixes broken tests

### DIFF
--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,6 +1,19 @@
 import resolver from './helpers/resolver';
-import {
-  setResolver
-} from 'ember-qunit';
+import QU from 'ember-qunit';
 
-setResolver(resolver);
+/**
+* Basic helper function to mark tests as pending.
+* NOTE: This still marks the test as passed. It does style the output in the browser.
+*       No phantomJS support as of right now.
+*
+* @method pending
+*/
+QU.pending = function() {
+  QU.test(arguments[0] + ' (PENDING TEST)', function(assert) {
+    assert.ok(!0); //dont expect any tests
+
+    $('.running').css('background', '#FFFF99');
+  });
+};
+
+QU.setResolver(resolver);


### PR DESCRIPTION
Support for pending tests was accidentally left out in: https://github.com/basho-labs/riak-explorer-gui/commit/fa5e308620c171813ef15d92724462434cd54d61

This re-adds them back and gets the test suite running green again.
