### PR TITLE
Refactor. Inject store into explorer service

### DIFF
--- a/app/initializers/explorer.js
+++ b/app/initializers/explorer.js
@@ -1,5 +1,8 @@
 export function initialize(container, app) {
+  // inject explorer service into all routes
   app.inject('route', 'explorer', 'service:explorer');
+  // inject the store into the explorer service
+  app.inject('service:explorer', 'store', 'store:main');
 }
 
 export default {

--- a/app/pods/bucket-type/controller.js
+++ b/app/pods/bucket-type/controller.js
@@ -14,6 +14,7 @@ var BucketTypeController = Ember.Controller.extend({
    */
   pollForModel: function(bucketType, delay) {
     var self = this;
+
     Ember.run.later(function() {
       // console.log('controller: scheduling to refreshModel');
       self.refreshModel(bucketType);
@@ -30,16 +31,20 @@ var BucketTypeController = Ember.Controller.extend({
    */
   refreshModel: function(bucketType) {
     var self = this;
+
     // console.log("Refreshing model %O", bucketType);
     var cluster = bucketType.get('cluster');
-    self.get('explorer').getBucketList(cluster,
-      bucketType, self.store)
+
+    self.get('explorer').getBucketList(cluster, bucketType)
       .then(function(updatedBucketList) {
         // console.log('loaded bucket list: %O', updatedBucketList);
         var model = self.get('model');
+
         model.set('bucketList', updatedBucketList);
+
         if (!model.get('isBucketListLoaded') &&
           updatedBucketList.get('cachePresent')) {
+
           // Only continue polling in development mode
           self.pollForModel(model, 3000);
         }
@@ -51,9 +56,8 @@ var BucketTypeController = Ember.Controller.extend({
       let service = this.get('explorer');
       let bucketType = this.get('model');
       let cluster = bucketType.get('cluster');
-      let store = this.get('store');
 
-      return service.getBucketTypeWithBucketList(bucketType, cluster, store, startIndex);
+      return service.getBucketTypeWithBucketList(bucketType, cluster, startIndex);
     },
 
     refreshBuckets: function(bucketType) {

--- a/app/pods/bucket-type/route.js
+++ b/app/pods/bucket-type/route.js
@@ -6,12 +6,11 @@ export default Ember.Route.extend(SideBarSelect, {
     var clusterId = params.clusterId;
     var bucketTypeId = params.bucketTypeId;
     var explorer = this.explorer;
-    var store = this.store;
 
     return this.explorer
-      .getBucketType(clusterId, bucketTypeId, store)
+      .getBucketType(clusterId, bucketTypeId)
       .then(function(bucketType) {
-        return explorer.getBucketTypeWithBucketList(bucketType, bucketType.get('cluster'), store);
+        return explorer.getBucketTypeWithBucketList(bucketType, bucketType.get('cluster'));
       });
   },
 
@@ -21,6 +20,7 @@ export default Ember.Route.extend(SideBarSelect, {
 
   setupController: function(controller, model) {
     this._super(controller, model);
+
     if (!model.get('isBucketListLoaded')) {
       controller.pollForModel(model, 3000);
     }

--- a/app/pods/bucket/controller.js
+++ b/app/pods/bucket/controller.js
@@ -29,7 +29,8 @@ var BucketController = Ember.Controller.extend({
   refreshModel: function(bucket) {
     var self = this;
     var cluster = bucket.get('cluster');
-    self.get('explorer').getKeyList(bucket, self.store)
+
+    self.get('explorer').getKeyList(bucket)
       .then(function(updatedKeyList) {
         // The key list could be either loaded or empty at this point
         bucket.set('keyList', updatedKeyList);
@@ -45,16 +46,17 @@ var BucketController = Ember.Controller.extend({
     retrieveRequestedKeys: function(startIndex) {
       let service = this.get('explorer');
       let bucket = this.get('model');
-      let store = this.get('store');
 
-      return service.getBucketWithKeyList(bucket, store, startIndex);
+      return service.getBucketWithKeyList(bucket, startIndex);
     },
 
     deleteBucket: function(bucket) {
       bucket.set('isKeyListLoaded', false);
       this.get('explorer').deleteBucket(bucket);
+
       // Reload the model after the delete, triggers a cache refresh
       this.pollForModel(bucket, 5000);
+
       // Reload the second time
       this.pollForModel(bucket, 10000);
     },

--- a/app/pods/bucket/route.js
+++ b/app/pods/bucket/route.js
@@ -4,12 +4,11 @@ import SideBarSelect from '../../mixins/sidebar-select';
 export default Ember.Route.extend(SideBarSelect, {
   model: function(params) {
     let explorer = this.explorer;
-    let store = this.store;
 
     return explorer
-      .getBucket(params.clusterId, params.bucketTypeId, params.bucketId, store)
+      .getBucket(params.clusterId, params.bucketTypeId, params.bucketId)
       .then(function(bucket) {
-        return explorer.getBucketWithKeyList(bucket, store);
+        return explorer.getBucketWithKeyList(bucket);
       });
   },
 
@@ -29,7 +28,7 @@ export default Ember.Route.extend(SideBarSelect, {
     //   function, above, is not called. Handle this case.
     if (Ember.isEmpty(model.get('props'))) {
       this.explorer
-        .getBucketProps(model.get('clusterId'), model.get('bucketTypeId'), model.get('bucketId'), this.store)
+        .getBucketProps(model.get('clusterId'), model.get('bucketTypeId'), model.get('bucketId'))
         .then(function(bucketProps) {
           model.set('props', bucketProps);
         });

--- a/app/pods/cluster/route.js
+++ b/app/pods/cluster/route.js
@@ -19,11 +19,11 @@ export default Ember.Route.extend(SideBarSelect, {
   },
 
   model: function(params) {
-    return this.explorer.getCluster(params.clusterId, this.store);
+    return this.explorer.getCluster(params.clusterId);
   },
 
   afterModel: function(model, transition) {
     this.setSidebarCluster(model);
-    this.explorer.pingNodesInCluster(model, this.store);
+    this.explorer.pingNodesInCluster(model);
   }
 });

--- a/app/pods/log-file/route.js
+++ b/app/pods/log-file/route.js
@@ -4,7 +4,7 @@ import SideBarSelect from '../../mixins/sidebar-select';
 export default Ember.Route.extend(SideBarSelect, {
 
   model: function(params) {
-    return this.explorer.getLogFile(params.clusterId, params.nodeId, params.logId, this.store);
+    return this.explorer.getLogFile(params.clusterId, params.nodeId, params.logId);
   },
 
   afterModel: function(model, transition) {

--- a/app/pods/node/route.js
+++ b/app/pods/node/route.js
@@ -3,7 +3,7 @@ import SideBarSelect from '../../mixins/sidebar-select';
 
 export default Ember.Route.extend(SideBarSelect, {
   model: function(params) {
-    return this.explorer.getNode(params.clusterId, params.nodeId, this.store);
+    return this.explorer.getNode(params.clusterId, params.nodeId);
   },
 
   afterModel: function(model, transition) {

--- a/app/pods/riak-object/counter/controller.js
+++ b/app/pods/riak-object/counter/controller.js
@@ -31,4 +31,5 @@ var RiakObjectCounterController = RiakObjectController.extend({
     }
   }
 });
+
 export default RiakObjectCounterController;

--- a/app/pods/riak-object/edit/route.js
+++ b/app/pods/riak-object/edit/route.js
@@ -4,12 +4,10 @@ import SideBarSelect from '../../../mixins/sidebar-select';
 var RiakObjectEditRoute = Ember.Route.extend(SideBarSelect, {
   model: function(params) {
     var explorer = this.explorer;
-    var store = this.store;
 
-    return explorer.getBucket(params.clusterId,
-      params.bucketTypeId, params.bucketId, store)
+    return explorer.getBucket(params.clusterId, params.bucketTypeId, params.bucketId)
       .then(function(bucket) {
-        return explorer.getRiakObject(bucket, params.key, store);
+        return explorer.getRiakObject(bucket, params.key);
       });
   },
 

--- a/app/pods/riak-object/route.js
+++ b/app/pods/riak-object/route.js
@@ -16,11 +16,10 @@ var RiakObjectRoute = Ember.Route.extend(SideBarSelect, {
 
   model: function(params) {
     var explorer = this.explorer;
-    var store = this.store;
-    return explorer.getBucket(params.clusterId,
-      params.bucketTypeId, params.bucketId, store)
+
+    return explorer.getBucket(params.clusterId, params.bucketTypeId, params.bucketId)
       .then(function(bucket) {
-        return explorer.getRiakObject(bucket, params.key, store);
+        return explorer.getRiakObject(bucket, params.key);
       });
   },
 
@@ -30,9 +29,9 @@ var RiakObjectRoute = Ember.Route.extend(SideBarSelect, {
 
   setupController: function(controller, model) {
     this._super(controller, model);
+
     if (!model.get('isLoaded')) {
-      this.explorer.getRiakObject(model.get('bucket'),
-        model.get('key'), this.store)
+      this.explorer.getRiakObject(model.get('bucket'), model.get('key'))
         .then(function(object) {
           controller.set('model', object);
         });

--- a/app/pods/search-index/route.js
+++ b/app/pods/search-index/route.js
@@ -3,7 +3,7 @@ import SideBarSelect from '../../mixins/sidebar-select';
 
 export default Ember.Route.extend(SideBarSelect, {
   model: function(params) {
-    return this.explorer.getCluster(params.clusterId, this.store)
+    return this.explorer.getCluster(params.clusterId)
       .then(function(cluster) {
         return cluster.get('searchIndexes').findBy('name', params.searchIndexId);
       });

--- a/app/pods/search-schema/create/route.js
+++ b/app/pods/search-schema/create/route.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model(params) {
-    return this.explorer.getCluster(params.clusterId, this.store);
+    return this.explorer.getCluster(params.clusterId);
   },
 
   afterModel(model, transition) {

--- a/app/pods/search-schema/edit/route.js
+++ b/app/pods/search-schema/edit/route.js
@@ -3,7 +3,7 @@ import SideBarSelect from '../../../mixins/sidebar-select';
 
 export default Ember.Route.extend(SideBarSelect, {
   model(params) {
-    return this.explorer.getCluster(params.clusterId, this.store)
+    return this.explorer.getCluster(params.clusterId)
       .then(function(cluster) {
         return cluster.get('searchSchemas').findBy('name', params.searchSchemaId);
       });

--- a/app/pods/search-schema/route.js
+++ b/app/pods/search-schema/route.js
@@ -5,12 +5,12 @@ export default Ember.Route.extend(SideBarSelect, {
   model(params) {
     let self = this;
 
-    return this.explorer.getCluster(params.clusterId, this.store)
+    return this.explorer.getCluster(params.clusterId)
       .then(function(cluster) {
         let schema = cluster.get('searchSchemas').findBy('name', params.searchSchemaId);
 
         if (!schema) {
-          schema = self.explorer.createSchema(params.searchSchemaId, cluster, self.store);
+          schema = self.explorer.createSchema(params.searchSchemaId, cluster);
         }
 
         return schema;


### PR DESCRIPTION
- Injects Ember Data store (`DS.store`) into the explorer service via the `explorer` initializer.
- Removes all the passing around of store inside of the explorer service, and the need to pass it in from method calls in the routes.

Ember Data and our own explorer service are already very much coupled, so we might as well make the experience cleaner.
