### PR TITLE
Add timeline to monitoring

### DIFF
--- a/app/components/charts/node-stat.js
+++ b/app/components/charts/node-stat.js
@@ -57,6 +57,7 @@ export default EmberHighChartsComponent.extend({
           y: stat.stats[statName]
         };
       }),
+      type: 'spline',
       turboThreshold: 0
     }]);
   },

--- a/app/components/charts/node-stat.js
+++ b/app/components/charts/node-stat.js
@@ -3,42 +3,33 @@ import _ from 'lodash/lodash';
 /*globals Highcharts */
 
 export default EmberHighChartsComponent.extend({
-  
-
   defaultOptions: {
-    chart: {
-      type: 'spline',
-      animation: Highcharts.svg
-    },
     title: {
       text: 'Node Data'
     },
-    xAxis: {
-      type: 'datetime',
-      tickPixelInterval: 150
-    },
-    yAxis: {
-      title: {
-        text: 'Value'
-      },
-      plotLines: [{
-        value: 0,
-        width: 1,
-        color: '#808080'
-      }]
-    },
-    tooltip: {
-      formatter: function () {
-        return '<b>' + this.series.name + '</b><br/>' +
-          Highcharts.dateFormat('%Y-%m-%d %H:%M:%S', this.x) + '<br/>' +
-          Highcharts.numberFormat(this.y, 2);
-      }
-    },
-    legend: {
-      enabled: false
-    },
-    exporting: {
-      enabled: false
+    rangeSelector: {
+      buttons: [{
+        count: 1,
+        type: 'minute',
+        text: '1M'
+      }, {
+        count: 5,
+        type: 'minute',
+        text: '5M'
+      }, {
+        count: 10,
+        type: 'minute',
+        text: '10M'
+      }, {
+        count: 30,
+        type: 'minute',
+        text: '30M'
+      }, {
+        type: 'all',
+        text: 'All'
+      }],
+      inputEnabled: false,
+      selected: 0
     }
   },
 
@@ -46,20 +37,16 @@ export default EmberHighChartsComponent.extend({
 
   statToGraph: null,
 
-  plotThreshold: 20,
-
   content: null,
 
   chartOptions: null,
 
-  getMostRecentStats: function() {
-    return _.takeRight(this.get('node').get('statsHistory'), this.get('plotThreshold'));
-  },
+  mode: "StockChart",
 
   setInitialData: function() {
     let statName = this.get('statToGraph');
     let options = _.assign(_.cloneDeep(this.defaultOptions), { title: { text: statName } });
-    let stats = this.getMostRecentStats();
+    let stats = this.get('node').get('statsHistory');
 
     this.set('chartOptions', options);
     this.set('content', [{
@@ -69,7 +56,8 @@ export default EmberHighChartsComponent.extend({
           x: stat.timestamp,
           y: stat.stats[statName]
         };
-      })
+      }),
+      turboThreshold: 0
     }]);
   },
 
@@ -81,22 +69,15 @@ export default EmberHighChartsComponent.extend({
   streamNewDataIntoChart: function() {
     let chart = this.get('chart');
     let series = _.head(chart.series);
-    let mostRecentStats = this.getMostRecentStats();
+    let stats = this.get('node').get('statsHistory');
     let statName = this.get('chartOptions.title.text');
-    let plotThreshold = this.get('plotThreshold');
 
-    if (mostRecentStats.length < plotThreshold) {
-      series.setData(mostRecentStats.map(function(stat) {
-        return {
-          x: stat.timestamp,
-          y: stat.stats[statName]
-        };
-      }));
-    } else {
-      let latestStat = _.last(mostRecentStats);
-
-      series.addPoint([latestStat.timestamp, latestStat.stats[statName]], true, true);
-    }
+    series.setData(stats.map(function(stat) {
+      return {
+        x: stat.timestamp,
+        y: stat.stats[statName]
+      };
+    }));
   }.observes('node.stats'),
 
   switchChart: function() {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,6 +7,15 @@ module.exports = function(defaults) {
     codemirror: {
       modes: ['javascript', 'sql', 'erlang', 'xml'],
       themes: ['material']
+    },
+
+    emberHighCharts: {
+      includeHighCharts: false,
+      includeHighStock: true
+      /* available modules:
+       boost, broken-axis, canvas-tools, data, drilldown, exporting, funnel,
+       heatmap, map, no-data-to-display, offline-exporting, solid-gauge, treemap
+       */
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -37,11 +37,8 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.5.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-highcharts": "0.4.4",
     "ember-load-initializers": "^0.5.1",
-    "ember-local-storage": "1.3.1",
     "ember-resolver": "^2.0.3",
-    "highcharts": "4.2.5",
     "loader.js": "^4.0.1"
   },
   "dependencies": {
@@ -49,6 +46,8 @@
     "ember-cli-loading-slider": "^1.3.0",
     "ember-cli-sass": "^5.1.0",
     "ember-content-editable": "0.7.0",
+    "ember-highcharts": "0.4.4",
+    "ember-local-storage": "1.3.1",
     "ember-lodash": "0.0.6",
     "ember-modal-dialog": "0.8.4",
     "ember-power-select": "0.7.2",
@@ -56,6 +55,7 @@
     "ember-truth-helpers": "1.2.0",
     "ember-validations": "0.0.0",
     "ember-wormhole": "^0.3.5",
+    "highcharts": "4.2.6",
     "ivy-codemirror": "1.4.0",
     "ivy-tabs": "2.0.0"
   }


### PR DESCRIPTION
- Saves entire session history, allows user to view it as a timeline
- Ability to view in time blocks (1, 5, 10, 30 minutes)
- Continuosly stream data or view a specific time block
