### PR TITLE
Enforce space before parenthesis on table creation statement

### DIFF
--- a/app/pods/table/create/route.js
+++ b/app/pods/table/create/route.js
@@ -3,6 +3,7 @@ import Alerts from '../../../mixins/routes/alerts';
 import LoadingSlider from '../../../mixins/routes/loading-slider';
 import ScrollReset from '../../../mixins/routes/scroll-reset';
 import WrapperState from '../../../mixins/routes/wrapper-state';
+import insert from '../../../utils/string-helpers';
 import _ from 'lodash/lodash';
 
 export default Ember.Route.extend(Alerts, LoadingSlider, ScrollReset, WrapperState, {
@@ -67,6 +68,13 @@ export default Ember.Route.extend(Alerts, LoadingSlider, ScrollReset, WrapperSta
                                       .replace(/(\r\n|\n|\r)/gm, ' ') // removes any leftover newlines
                                       .replace(/\( /g, '(')           // removes any spacing following left parenthesis
                                       .replace(/ \)/g, ')'));         // removes any spacing preceding right parenthesis
+
+      // Add space before first parenthesis if needed
+      let indexOfFirstParenthesis = formatted.indexOf('(');
+      let indexOfCharacterBeforeFirstParenthesis = indexOfFirstParenthesis - 1;
+      let characterBeforeFirstParenthesis = formatted[indexOfCharacterBeforeFirstParenthesis];
+
+      if (characterBeforeFirstParenthesis !== ' ') { formatted = insert(formatted, indexOfFirstParenthesis, ' '); }
 
       let tableName = formatted.split(' ')[2]; // Table name should always come after CREATE TABLE
 

--- a/app/utils/string-helpers.js
+++ b/app/utils/string-helpers.js
@@ -1,0 +1,6 @@
+// function inserts the string value (third parameter) before the specified integer index (second parameter) in the
+// string str (first parameter), and then returns the new string without changing str!
+// i.e insert("foo baz", 4, "bar ") => "foo bar baz";
+export default function insert(str, index, value) {
+  return str.substr(0, index) + value + str.substr(index);
+}


### PR DESCRIPTION
Fixes https://github.com/basho-labs/riak_explorer/issues/148
- Enforces a space before the first parenthesis in a table creation statement
